### PR TITLE
fix: omit empty ClientSecret from DCR response

### DIFF
--- a/examples/who-am-i/config.yaml
+++ b/examples/who-am-i/config.yaml
@@ -3,7 +3,9 @@ authorization:
   server: http://dex:5556/
   authorizationProxyEnabled: true
   serverMetadataProxyEnabled: true
-  dynamicClientRegistrationEnabled: true
+  dynamicClientRegistration:
+    enabled: true
+    publicClient: true
 dexGRPCClient:
   addr: dex:5557
 proxy:

--- a/oauth/dynamic_client_registration.go
+++ b/oauth/dynamic_client_registration.go
@@ -18,8 +18,8 @@ const DynamicClientRegistrationPath = "/oauth/register"
 
 type ClientInformation struct {
 	ClientID              string   `json:"client_id"`
-	ClientSecret          string   `json:"client_secret"`
-	ClientSecretExpiresAt int64    `json:"client_secret_expires_at"`
+	ClientSecret          string   `json:"client_secret,omitempty"`
+	ClientSecretExpiresAt int64    `json:"client_secret_expires_at,omitempty"`
 	ClientName            string   `json:"client_name,omitempty"`
 	RedirectURIs          []string `json:"redirect_uris"`
 	LogoURI               string   `json:"logo_uri,omitempty"`


### PR DESCRIPTION
Previously, we sent an empty string instead, which confused some clients including Claude Code and VSCode