### PR TITLE
fix: rewrite auth server URLs for remote deployments

### DIFF
--- a/oauth/authorization.go
+++ b/oauth/authorization.go
@@ -22,11 +22,15 @@ func NewAuthorizationHandler(config *config.Config, meta map[string]any) (http.H
 
 	if authorizationEndpointStr, ok := meta["authorization_endpoint"].(string); !ok {
 		return nil, errors.New("authorization metadata is missing authorization_endpoint field")
-	} else if _, err := url.Parse(authorizationEndpointStr); err != nil {
+	} else if authEndpointURL, err := url.Parse(authorizationEndpointStr); err != nil {
 		return nil, fmt.Errorf("could not parse authorization endpoint: %w", err)
 	} else {
+		// Rewrite the authorization endpoint to use the public host URL
+		publicURL, _ := url.Parse(config.Host.String())
+		publicURL.Path = authEndpointURL.Path
+
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			redirectURI, _ := url.Parse(authorizationEndpointStr)
+			redirectURI := *publicURL
 			q := r.URL.Query()
 			scopes := q.Get("scope")
 			for _, scope := range requiredScopes {

--- a/oauth/authorization.go
+++ b/oauth/authorization.go
@@ -26,7 +26,10 @@ func NewAuthorizationHandler(config *config.Config, meta map[string]any) (http.H
 		return nil, fmt.Errorf("could not parse authorization endpoint: %w", err)
 	} else {
 		// Rewrite the authorization endpoint to use the public host URL
-		publicURL, _ := url.Parse(config.Host.String())
+		publicURL, err := url.Parse(config.Host.String())
+		if err != nil {
+			return nil, fmt.Errorf("could not parse public host URL: %w", err)
+		}
 		publicURL.Path = authEndpointURL.Path
 
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/oauth/authorization_server_metadata.go
+++ b/oauth/authorization_server_metadata.go
@@ -47,10 +47,12 @@ func NewAuthorizationServerMetadataHandler(config *config.Config) http.Handler {
 				metadata["authorization_endpoint"] = authorizationURI.String()
 				log.Get(r.Context()).Info("Adding authorization endpoint to authorization server metadata",
 					"url", metadata["authorization_endpoint"])
-			}
 
-			// Rewrite all URL fields pointing to internal auth server to public host
-			rewriteMetadataURLs(metadata, config.Authorization.Server, config.Host.String())
+				// Rewrite endpoint URL fields pointing to internal auth server
+				// to public host so external clients can reach them through the
+				// gateway's reverse proxy.
+				rewriteMetadataURLs(metadata, config.Authorization.Server, config.Host.String())
+			}
 
 			w.Header().Set("Content-Type", "application/json")
 			if err := json.NewEncoder(w).Encode(metadata); err != nil {
@@ -97,14 +99,48 @@ func GetMedatata(server string) (map[string]any, error) {
 	return nil, err
 }
 
-// rewriteMetadataURLs rewrites all string values in metadata that start with
-// the internal auth server URL to use the public host URL instead.
+// endpointURLFields lists the metadata fields that contain endpoint URLs
+// eligible for rewriting. Fields like "issuer" are intentionally excluded
+// because rewriting them would make the metadata inconsistent with the "iss"
+// claim in tokens issued by the auth server.
+var endpointURLFields = []string{
+	"authorization_endpoint",
+	"token_endpoint",
+	"jwks_uri",
+	"userinfo_endpoint",
+	"registration_endpoint",
+	"introspection_endpoint",
+	"revocation_endpoint",
+	"device_authorization_endpoint",
+	"end_session_endpoint",
+}
+
+// rewriteMetadataURLs rewrites known endpoint URL fields in metadata from the
+// internal auth server URL to the public host URL. Only fields whose
+// scheme and host match the internal server are rewritten.
 func rewriteMetadataURLs(metadata map[string]any, internalServer string, publicHost string) {
-	internal := strings.TrimRight(internalServer, "/")
-	public := strings.TrimRight(publicHost, "/")
-	for key, value := range metadata {
-		if s, ok := value.(string); ok && strings.HasPrefix(s, internal) {
-			metadata[key] = strings.Replace(s, internal, public, 1)
+	internalURL, err := url.Parse(strings.TrimRight(internalServer, "/"))
+	if err != nil || internalURL.Scheme == "" || internalURL.Host == "" {
+		return
+	}
+	publicURL, err := url.Parse(strings.TrimRight(publicHost, "/"))
+	if err != nil || publicURL.Scheme == "" || publicURL.Host == "" {
+		return
+	}
+
+	for _, key := range endpointURLFields {
+		s, ok := metadata[key].(string)
+		if !ok {
+			continue
+		}
+		u, err := url.Parse(s)
+		if err != nil || u.Scheme == "" || u.Host == "" {
+			continue
+		}
+		if u.Scheme == internalURL.Scheme && u.Host == internalURL.Host {
+			u.Scheme = publicURL.Scheme
+			u.Host = publicURL.Host
+			metadata[key] = u.String()
 		}
 	}
 }

--- a/oauth/authorization_server_metadata.go
+++ b/oauth/authorization_server_metadata.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strings"
 
 	"github.com/hyprmcp/mcp-gateway/config"
 	"github.com/hyprmcp/mcp-gateway/log"
@@ -47,6 +48,9 @@ func NewAuthorizationServerMetadataHandler(config *config.Config) http.Handler {
 				log.Get(r.Context()).Info("Adding authorization endpoint to authorization server metadata",
 					"url", metadata["authorization_endpoint"])
 			}
+
+			// Rewrite all URL fields pointing to internal auth server to public host
+			rewriteMetadataURLs(metadata, config.Authorization.Server, config.Host.String())
 
 			w.Header().Set("Content-Type", "application/json")
 			if err := json.NewEncoder(w).Encode(metadata); err != nil {
@@ -91,6 +95,18 @@ func GetMedatata(server string) (map[string]any, error) {
 	}
 
 	return nil, err
+}
+
+// rewriteMetadataURLs rewrites all string values in metadata that start with
+// the internal auth server URL to use the public host URL instead.
+func rewriteMetadataURLs(metadata map[string]any, internalServer string, publicHost string) {
+	internal := strings.TrimRight(internalServer, "/")
+	public := strings.TrimRight(publicHost, "/")
+	for key, value := range metadata {
+		if s, ok := value.(string); ok && strings.HasPrefix(s, internal) {
+			metadata[key] = strings.Replace(s, internal, public, 1)
+		}
+	}
 }
 
 func getMetadataURIs(server string) ([]string, error) {

--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/http/httputil"
 	"net/url"
 	"strings"
 	"time"
@@ -32,29 +33,48 @@ func NewManager(ctx context.Context, config *config.Config) (*Manager, error) {
 	timeoutCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	if cache, err := jwk.NewCache(ctx, httprc.NewClient(
+	cache, err := jwk.NewCache(ctx, httprc.NewClient(
 		httprc.WithTraceSink(tracesink.Func(func(ctx context.Context, s string) { log.V(1).Info(s) })),
 		httprc.WithErrorSink(errsink.NewFunc(func(ctx context.Context, err error) { log.V(1).Error(err, "httprc.NewClient error") })),
-	)); err != nil {
+	))
+	if err != nil {
 		return nil, fmt.Errorf("jwk cache creation error: %w", err)
-	} else if meta, err := GetMedatata(config.Authorization.Server); err != nil {
+	}
+
+	meta, err := GetMedatata(config.Authorization.Server)
+	if err != nil {
 		return nil, fmt.Errorf("authorization server metadata error: %w", err)
-	} else if jwksURI, ok := meta["jwks_uri"].(string); !ok {
+	}
+
+	jwksURIRaw, ok := meta["jwks_uri"].(string)
+	if !ok {
 		return nil, errors.New("no jwks_uri")
-	} else if err := cache.Register(
-		timeoutCtx,
-		jwksURI,
+	}
+
+	// Build internal JWKS URI using the auth server address to avoid a
+	// circular dependency when the auth server's issuer is set to the
+	// public gateway URL (the metadata would advertise the gateway's own
+	// URL as jwks_uri, causing the gateway to fetch from itself).
+	internalJWKSURI := strings.TrimRight(config.Authorization.Server, "/") + "/keys"
+	if u, err := url.Parse(jwksURIRaw); err == nil {
+		internalJWKSURI = strings.TrimRight(config.Authorization.Server, "/") + u.Path
+	}
+
+	if err := cache.Register(timeoutCtx, internalJWKSURI,
 		jwk.WithMinInterval(10*time.Second),
 		jwk.WithMaxInterval(5*time.Minute),
 	); err != nil {
 		return nil, fmt.Errorf("jwks registration error: %w", err)
-	} else if _, err := cache.Refresh(timeoutCtx, jwksURI); err != nil {
-		return nil, fmt.Errorf("jwks refresh error: %w", err)
-	} else if s, err := cache.CachedSet(jwksURI); err != nil {
-		return nil, fmt.Errorf("jwks cache set error: %w", err)
-	} else {
-		return &Manager{jwkSet: s, config: config, authServerMeta: meta}, nil
 	}
+	if _, err := cache.Refresh(timeoutCtx, internalJWKSURI); err != nil {
+		return nil, fmt.Errorf("jwks refresh error: %w", err)
+	}
+	s, err := cache.CachedSet(internalJWKSURI)
+	if err != nil {
+		return nil, fmt.Errorf("jwks cache set error: %w", err)
+	}
+
+	return &Manager{jwkSet: s, config: config, authServerMeta: meta}, nil
 }
 
 func (mgr *Manager) Register(mux *http.ServeMux) error {
@@ -78,6 +98,24 @@ func (mgr *Manager) Register(mux *http.ServeMux) error {
 			return err
 		} else {
 			mux.Handle(AuthorizationPath, handler)
+		}
+
+		// Reverse-proxy auth server endpoints so that external clients can
+		// reach them through the public gateway URL. Paths are derived from
+		// the authorization server metadata (token, jwks, userinfo, etc.).
+		authURL, err := url.Parse(mgr.config.Authorization.Server)
+		if err != nil {
+			return fmt.Errorf("failed to parse auth server URL: %w", err)
+		}
+		authProxy := &httputil.ReverseProxy{
+			Rewrite: func(r *httputil.ProxyRequest) {
+				r.Out.URL.Scheme = authURL.Scheme
+				r.Out.URL.Host = authURL.Host
+				r.Out.Host = ""
+			},
+		}
+		for _, path := range authServerProxyPaths(mgr.authServerMeta) {
+			mux.Handle(path, authProxy)
 		}
 	}
 
@@ -109,4 +147,57 @@ func (mgr *Manager) getMetadataURL(u *url.URL) *url.URL {
 	metadataURL.Path = ProtectedResourcePath
 	metadataURL = metadataURL.JoinPath(u.Path)
 	return metadataURL
+}
+
+// authServerProxyPaths returns the HTTP paths that should be reverse-proxied
+// to the authorization server. Standard endpoint paths are extracted from the
+// authorization server metadata. The authorization endpoint is also registered
+// as a prefix pattern (trailing slash) so that connector sub-paths (e.g.
+// /auth/github) are proxied as well.
+func authServerProxyPaths(meta map[string]any) []string {
+	endpointKeys := []string{
+		"token_endpoint",
+		"jwks_uri",
+		"userinfo_endpoint",
+		"introspection_endpoint",
+		"revocation_endpoint",
+		"device_authorization_endpoint",
+		"end_session_endpoint",
+	}
+
+	seen := make(map[string]bool)
+	var paths []string
+	add := func(p string) {
+		if p != "" && p != "/" && !seen[p] {
+			seen[p] = true
+			paths = append(paths, p)
+		}
+	}
+
+	for _, key := range endpointKeys {
+		if s, ok := meta[key].(string); ok {
+			if u, err := url.Parse(s); err == nil {
+				add(u.Path)
+			}
+		}
+	}
+
+	// Register the authorization endpoint both as an exact match and as a
+	// prefix pattern so that connector-specific sub-paths (e.g.
+	// /auth/github) are also proxied.
+	if s, ok := meta["authorization_endpoint"].(string); ok {
+		if u, err := url.Parse(s); err == nil {
+			add(u.Path)
+			add(strings.TrimRight(u.Path, "/") + "/")
+		}
+	}
+
+	// Common auth server paths that are not advertised in metadata but are
+	// required for the OAuth flow when the auth server uses external
+	// identity provider connectors (e.g. the IdP redirects back to
+	// /callback after user authentication).
+	add("/callback")
+	add("/approval")
+
+	return paths
 }

--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -55,9 +55,21 @@ func NewManager(ctx context.Context, config *config.Config) (*Manager, error) {
 	// circular dependency when the auth server's issuer is set to the
 	// public gateway URL (the metadata would advertise the gateway's own
 	// URL as jwks_uri, causing the gateway to fetch from itself).
-	internalJWKSURI := strings.TrimRight(config.Authorization.Server, "/") + "/keys"
-	if u, err := url.Parse(jwksURIRaw); err == nil {
-		internalJWKSURI = strings.TrimRight(config.Authorization.Server, "/") + u.Path
+	baseURL, err := url.Parse(config.Authorization.Server)
+	if err != nil {
+		return nil, fmt.Errorf("invalid authorization server URL %q: %w", config.Authorization.Server, err)
+	}
+	jwksURL, err := url.Parse(jwksURIRaw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid jwks_uri %q: %w", jwksURIRaw, err)
+	}
+	jwksPath := jwksURL.Path
+	if jwksPath == "" || jwksPath == "/" {
+		jwksPath = "/keys"
+	}
+	internalJWKSURI, err := url.JoinPath(baseURL.String(), jwksPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct internal JWKS URI: %w", err)
 	}
 
 	if err := cache.Register(timeoutCtx, internalJWKSURI,
@@ -176,7 +188,7 @@ func authServerProxyPaths(meta map[string]any) []string {
 
 	for _, key := range endpointKeys {
 		if s, ok := meta[key].(string); ok {
-			if u, err := url.Parse(s); err == nil {
+			if u, err := url.Parse(s); err == nil && strings.HasPrefix(u.Path, "/") {
 				add(u.Path)
 			}
 		}
@@ -186,7 +198,7 @@ func authServerProxyPaths(meta map[string]any) []string {
 	// prefix pattern so that connector-specific sub-paths (e.g.
 	// /auth/github) are also proxied.
 	if s, ok := meta["authorization_endpoint"].(string); ok {
-		if u, err := url.Parse(s); err == nil {
+		if u, err := url.Parse(s); err == nil && strings.HasPrefix(u.Path, "/") {
 			add(u.Path)
 			add(strings.TrimRight(u.Path, "/") + "/")
 		}

--- a/oauth/oauth_test.go
+++ b/oauth/oauth_test.go
@@ -1,0 +1,101 @@
+package oauth
+
+import (
+	"testing"
+)
+
+func TestAuthServerProxyPaths(t *testing.T) {
+	tests := []struct {
+		name     string
+		meta     map[string]any
+		wantLen  int
+		contains []string
+		excludes []string
+	}{
+		{
+			name: "extracts standard endpoint paths from metadata",
+			meta: map[string]any{
+				"issuer":                        "https://example.com",
+				"authorization_endpoint":        "https://example.com/auth",
+				"token_endpoint":                "https://example.com/token",
+				"jwks_uri":                      "https://example.com/keys",
+				"userinfo_endpoint":             "https://example.com/userinfo",
+				"introspection_endpoint":        "https://example.com/token/introspect",
+				"device_authorization_endpoint": "https://example.com/device/code",
+			},
+			contains: []string{
+				"/token",
+				"/keys",
+				"/userinfo",
+				"/token/introspect",
+				"/device/code",
+				"/auth",
+				"/auth/",
+				"/callback",
+				"/approval",
+			},
+			excludes: []string{"/"},
+		},
+		{
+			name: "does not duplicate paths",
+			meta: map[string]any{
+				"token_endpoint":    "https://example.com/token",
+				"jwks_uri":         "https://example.com/token", // same path
+				"userinfo_endpoint": "https://example.com/userinfo",
+			},
+			contains: []string{"/token", "/userinfo", "/callback", "/approval"},
+		},
+		{
+			name:     "handles empty metadata",
+			meta:     map[string]any{},
+			contains: []string{"/callback", "/approval"},
+			wantLen:  2,
+		},
+		{
+			name: "skips non-string and unparseable values",
+			meta: map[string]any{
+				"token_endpoint":    42,
+				"jwks_uri":         "https://example.com/keys",
+				"userinfo_endpoint": "://invalid",
+			},
+			contains: []string{"/keys", "/callback", "/approval"},
+		},
+		{
+			name: "registers authorization endpoint prefix for sub-paths",
+			meta: map[string]any{
+				"authorization_endpoint": "https://example.com/dex/auth",
+			},
+			contains: []string{"/dex/auth", "/dex/auth/"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			paths := authServerProxyPaths(tt.meta)
+
+			if tt.wantLen > 0 && len(paths) != tt.wantLen {
+				t.Errorf("got %d paths, want %d: %v", len(paths), tt.wantLen, paths)
+			}
+
+			pathSet := make(map[string]bool)
+			for _, p := range paths {
+				if pathSet[p] {
+					t.Errorf("duplicate path: %s", p)
+				}
+				pathSet[p] = true
+			}
+
+			for _, want := range tt.contains {
+				if !pathSet[want] {
+					t.Errorf("missing expected path %q in %v", want, paths)
+				}
+			}
+
+			for _, exclude := range tt.excludes {
+				if pathSet[exclude] {
+					t.Errorf("unexpected path %q in %v", exclude, paths)
+				}
+			}
+		})
+	}
+}

--- a/oauth/oauth_test.go
+++ b/oauth/oauth_test.go
@@ -61,6 +61,15 @@ func TestAuthServerProxyPaths(t *testing.T) {
 			contains: []string{"/keys", "/callback", "/approval"},
 		},
 		{
+			name: "skips relative URIs that would panic ServeMux",
+			meta: map[string]any{
+				"token_endpoint": "token",        // relative, no leading /
+				"jwks_uri":       "https://example.com/keys",
+			},
+			contains: []string{"/keys", "/callback", "/approval"},
+			excludes: []string{"token"},
+		},
+		{
 			name: "registers authorization endpoint prefix for sub-paths",
 			meta: map[string]any{
 				"authorization_endpoint": "https://example.com/dex/auth",


### PR DESCRIPTION
## Summary

When the authorization server (e.g. Dex) runs on an internal network with its issuer set to the public gateway URL, external clients receive internal URLs they cannot reach, and the gateway encounters a circular dependency fetching JWKS from itself.

This PR fixes three related issues that arise in remote/reverse-proxy deployments where `authorization.server` differs from `host`:

- **Authorization redirect**: rewrites the redirect URL to use the public host instead of the internal auth server address
- **Discovery metadata**: adds `rewriteMetadataURLs()` to rewrite all URL fields in the `/.well-known/oauth-authorization-server` response from internal to public
- **JWKS circular dependency**: extracts the path from the advertised `jwks_uri` and prepends the internal `authorization.server` address, so the gateway fetches keys directly from the auth server instead of from itself
- **Auth server endpoint proxy**: when `authorizationProxyEnabled` is set, reverse-proxies auth server endpoints (token, keys, userinfo, etc.) derived from the metadata so external clients can reach them through the public gateway URL

## Example scenario

```yaml
host: https://public-gateway.example.com/
authorization:
  server: http://dex:5556/  # internal, not reachable from outside
  authorizationProxyEnabled: true
```

Without this fix, external clients receive URLs like `http://dex:5556/token` in the discovery metadata and cannot complete the OAuth flow.

## Test plan

- [x] Unit tests for `authServerProxyPaths()` (5 cases: standard extraction, deduplication, empty metadata, invalid values, prefix patterns)
- [x] `go build ./...` passes
- [x] Manually tested full OAuth flow (DCR → authorization → GitHub login → callback → token exchange → authenticated MCP access) with Dex issuer set to public gateway URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)